### PR TITLE
Make time out plugin respect panel icon size

### DIFF
--- a/panel-plugin/time-out.c
+++ b/panel-plugin/time-out.c
@@ -203,7 +203,7 @@ time_out_new (XfcePanelPlugin *plugin)
 
   /* Create time out icon */
   time_out->panel_icon = gtk_image_new_from_icon_name ("xfce4-time-out-plugin", GTK_ICON_SIZE_DIALOG);
-  gtk_image_set_pixel_size (GTK_IMAGE (time_out->panel_icon), xfce_panel_plugin_get_size (time_out->plugin) - 8);
+  gtk_image_set_pixel_size (GTK_IMAGE (time_out->panel_icon), xfce_panel_plugin_get_icon_size (time_out->plugin));
   gtk_box_pack_start (GTK_BOX (time_out->hvbox), time_out->panel_icon, TRUE, TRUE, 0);
   gtk_widget_show (time_out->panel_icon);
 
@@ -382,7 +382,8 @@ time_out_size_changed (XfcePanelPlugin *plugin,
   orientation = xfce_panel_plugin_get_orientation (plugin);
 
   /* Update icon size */
-  gtk_image_set_pixel_size (GTK_IMAGE (time_out->panel_icon), size - 8);
+  gtk_image_set_pixel_size (GTK_IMAGE (time_out->panel_icon),
+			    xfce_panel_plugin_get_icon_size(time_out->plugin));
 
   /* Update widget size */
   if (orientation == GTK_ORIENTATION_HORIZONTAL)


### PR DESCRIPTION
  Since Xfce 4.14, each panel specifies an overall icon-size policy for all
  components therein. This change causes the timeout plugin to respect the panel
  setting.

  I recognize that the plugin maintainer is unlikely to monitor this mirror, I will file a bugzilla report referencing this pull request.